### PR TITLE
feat: socialgouv/actions/k8s-manifests-debug

### DIFF
--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -11,4 +11,5 @@ jobs:
         uses: ./k8s-manifests-debug
         with:
           manifests: kubernetes-manifests.yaml
+          token: ${{ secrets.GITHUB_TOKEN }}
       - run: echo ${{ steps.test.outputs.markdown }}

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: wget https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/master/release/kubernetes-manifests.yaml
       - id: test
-        uses: ./../k8s-manifests-debug
+        uses: ./../../k8s-manifests-debug
         with:
           manifests: kubernetes-man ifests.yaml
       - run: echo ${{ steps.test.outputs.markdown }}

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -11,4 +11,7 @@ jobs:
         with:
           path: ./k8s-manifests-debug/sample.yml
           token: ${{ secrets.GITHUB_TOKEN }}
-      - run: echo ${{ steps.test.outputs.markdown }}
+      - run: |
+        echo ${{ steps.test.outputs.markdown }}
+        echo ${{ steps.test.outputs.text }}
+        echo ${{ steps.test.outputs.json }}

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -1,0 +1,14 @@
+on: [push]
+
+jobs:
+  k8s-manifests-debug:
+    runs-on: ubuntu-latest
+    name: k8s-manifests-debug
+    steps:
+      - uses: actions/checkout@v2
+      - run: wget https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/master/release/kubernetes-manifests.yaml
+      - id: test
+        uses: ../k8s-manifests-debug
+        with:
+          manifests: kubernetes-manifests.yaml
+      - run: echo ${{ steps.test.outputs.markdown }}

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: wget https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/master/release/kubernetes-manifests.yaml
       - id: test
-        uses: ./../../k8s-manifests-debug
+        uses: ./k8s-manifests-debug
         with:
-          manifests: kubernetes-man ifests.yaml
+          manifests: kubernetes-manifests.yaml
       - run: echo ${{ steps.test.outputs.markdown }}

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -9,6 +9,6 @@ jobs:
       - id: test
         uses: ./k8s-manifests-debug
         with:
-          path: ./k8s-manifests-debug/sample.yaml
+          path: ./k8s-manifests-debug/sample.yml
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: echo ${{ steps.test.outputs.markdown }}

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -6,10 +6,9 @@ jobs:
     name: k8s-manifests-debug
     steps:
       - uses: actions/checkout@v2
-      - run: wget https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/master/release/kubernetes-manifests.yaml
       - id: test
         uses: ./k8s-manifests-debug
         with:
-          path: kubernetes-manifests.yaml
+          path: ./k8s-manifests-debug/sample.yaml
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: echo ${{ steps.test.outputs.markdown }}

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -26,6 +26,7 @@ jobs:
 
       - name: "text output is correct"
         run: |
+
           TEXT='
           ### Ingresses
 
@@ -52,6 +53,8 @@ jobs:
           #### 👮‍♂️ Rancher project undefined:
 
           https://rancher.fabrique.social.gouv.fr/p/some-project-id/workloads'
+
+          diff <(echo "$TEXT") <(echo "${{ steps.manifests-debug.outputs.text }}")
 
           if [[ "${TEXT}" != "${{ steps.manifests-debug.outputs.text }}" ]]; then
             echo "------------------"

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -6,6 +6,7 @@ jobs:
     name: k8s-manifests-debug tests
     steps:
       - uses: actions/checkout@v2
+
       - id: manifests-debug
         name: "⛑️ Debug Manifests ⛑️ "
         uses: ./k8s-manifests-debug
@@ -14,6 +15,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
         env:
           RANCHER_PROJECT_ID: some-project-id
+
       - name: "json output exist"
         run: |
           [[ -n "${{ steps.manifests-debug.outputs.json }}" ]] || (echo "No json" && exit 1)
@@ -24,7 +26,8 @@ jobs:
 
       - name: "text output is correct"
         run: |
-          TEXT='### Ingresses
+          TEXT='
+          ### Ingresses
 
           - 🚀 https://hello-world.info
 

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -30,11 +30,11 @@ jobs:
           TEXT='
           ### Ingresses
 
-          - 🚀 https://hello-world.info
+           - 🚀 https://hello-world.info
 
           ### Docker images
 
-          - 📦 docker pull nginx:1.14.2
+           - 📦 docker pull nginx:1.14.2
 
           ### Debug
 
@@ -55,16 +55,3 @@ jobs:
           https://rancher.fabrique.social.gouv.fr/p/some-project-id/workloads'
 
           diff <(echo "$TEXT") <(echo "${{ steps.manifests-debug.outputs.text }}")
-
-          if [[ "${TEXT}" != "${{ steps.manifests-debug.outputs.text }}" ]]; then
-            echo "------------------"
-            echo "Invalid TEXT"
-            echo "-"
-            echo "Expected:"
-            echo "${TEXT}"
-            echo "---"
-            echo "Actual:"
-            echo "${{ steps.manifests-debug.outputs.text }}"
-            echo "------------------"
-            exit 1
-          fi

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -41,7 +41,13 @@ jobs:
             ]
           }'
 
-          if [[ "$JSON" != "${{ steps.manifests-debug.outputs.json }}" ]]; then
+          if [[ "${JSON}" != "${{ steps.manifests-debug.outputs.json }}" ]]; then
+            echo "---"
             echo "Invalid JSON"
-            
+            echo "${JSON}"
+            echo "---"
+            echo "${{ steps.manifests-debug.outputs.json }}"
+            echo "---"
+            echo "${{ steps.manifests-debug.outputs.json }}"
+            exit 1
           fi

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: "text output is correct"
         run: |
 
-          TEXT='
+          EXPECTED='
           ### Ingresses
 
            - 🚀 https://hello-world.info
@@ -54,4 +54,4 @@ jobs:
 
           https://rancher.fabrique.social.gouv.fr/p/some-project-id/workloads'
 
-          diff <(echo "$TEXT") <(echo "${{ steps.manifests-debug.outputs.text }}")
+          diff <(echo "$EXPECTED") <(echo "${{ steps.manifests-debug.outputs.text }}")

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -13,7 +13,7 @@ jobs:
           path: ./k8s-manifests-debug/sample.yml
           token: ${{ secrets.GITHUB_TOKEN }}
         env:
-          HELLO: WORLD
+          RANCHER_PROJECT_ID: some-project-id
       - name: "json output exist"
         run: |
           [[ -n "${{ steps.manifests-debug.outputs.json }}" ]] || (echo "No json" && exit 1)
@@ -48,7 +48,7 @@ jobs:
 
           #### 👮‍♂️ Rancher project undefined:
 
-          https://rancher.fabrique.social.gouv.fr/p//workloads'
+          https://rancher.fabrique.social.gouv.fr/p/some-project-id/workloads'
 
           if [[ "${TEXT}" != "${{ steps.manifests-debug.outputs.text }}" ]]; then
             echo "------------------"

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -38,19 +38,19 @@ jobs:
 
           ### Debug
 
-          #### 📕 Loki logs for namespace undefined:
+          #### 📕 Loki logs for namespace some-namespace:
 
-          https://grafana.fabrique.social.gouv.fr/explore?orgId=1&left=%5B%22now-6h%22,%22now%22,%22Loki-tail%22,%7B%22expr%22:%22%7Bnamespace%3D%5C%22undefined%5C%22%7D%22%7D%5D
+          https://grafana.fabrique.social.gouv.fr/explore?orgId=1&left=%5B%22now-6h%22,%22now%22,%22Loki-tail%22,%7B%22expr%22:%22%7Bnamespace%3D%5C%22some-namespace%5C%22%7D%22%7D%5D
 
-          #### 📈 Pods monitoring for namespace undefined:
+          #### 📈 Pods monitoring for namespace some-namespace:
 
-          https://grafana.fabrique.social.gouv.fr/d/85a562078cdf77779eaa1add43ccec1e/kubernetes-compute-resources-namespace-pods?orgId=1&refresh=10s&var-datasource=default&var-cluster=dev2&var-namespace=undefined
+          https://grafana.fabrique.social.gouv.fr/d/85a562078cdf77779eaa1add43ccec1e/kubernetes-compute-resources-namespace-pods?orgId=1&refresh=10s&var-datasource=default&var-cluster=dev2&var-namespace=some-namespace
 
-          #### 📈 Workloads monitoring for namespace undefined:
+          #### 📈 Workloads monitoring for namespace some-namespace:
 
-          https://grafana.fabrique.social.gouv.fr/d/a87fb0d919ec0ea5f6543124e16c42a5/kubernetes-compute-resources-namespace-workloads?orgId=1&refresh=10s&var-datasource=default&var-cluster=dev2&var-namespace=undefined&var-type=deployment
+          https://grafana.fabrique.social.gouv.fr/d/a87fb0d919ec0ea5f6543124e16c42a5/kubernetes-compute-resources-namespace-workloads?orgId=1&refresh=10s&var-datasource=default&var-cluster=dev2&var-namespace=some-namespace&var-type=deployment
 
-          #### 👮‍♂️ Rancher project undefined:
+          #### 👮‍♂️ Rancher project some-namespace:
 
           https://rancher.fabrique.social.gouv.fr/p/some-project-id/workloads'
 

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -13,6 +13,6 @@ jobs:
           path: ./k8s-manifests-debug/sample.yml
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
-          echo ${{ steps.manifests-debug.outputs.markdown }}
-          echo ${{ steps.manifests-debug.outputs.text }}
-          echo ${{ steps.manifests-debug.outputs.json }}
+          echo "${{ steps.manifests-debug.outputs.markdown }}"
+          echo "${{ steps.manifests-debug.outputs.text }}"
+          echo "${{ steps.manifests-debug.outputs.json }}"

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -13,15 +13,13 @@ jobs:
           path: ./k8s-manifests-debug/sample.yml
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
-          echo 1
           [[ -n "${{ steps.manifests-debug.outputs.markdown }}" ]] || (echo "No markdown" && exit 1)
-          echo 2
-          [[ -n "${{ steps.manifests-debug.outputs.text }}" ]] || (echo "No text" && exit 1)
-          echo 3
-          [[ -n "$JSON" == "${{ steps.manifests-debug.outputs.json }}" ]] || (echo "Different JSON :/" && exit 1)
-          echo 4
+
       - run: |
-          echo 5
+          [[ -n "${{ steps.manifests-debug.outputs.text }}" ]] || (echo "No text" && exit 1)
+
+      - run: |
+          echo 3
           JSON='{
             "isProduction": false,
             "manifests": [

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -40,8 +40,8 @@ jobs:
               "nginx:1.14.2"
             ]
           }'
+
           if [[ "$JSON" != "${{ steps.manifests-debug.outputs.json }}" ]]; then
             echo "Invalid JSON"
-            echo "${{ steps.manifests-debug.outputs.json }}"
-            exit 1
+            
           fi

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -13,10 +13,15 @@ jobs:
           path: ./k8s-manifests-debug/sample.yml
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
+          echo 1
           [[ -n "${{ steps.manifests-debug.outputs.markdown }}" ]] || (echo "No markdown" && exit 1)
+          echo 2
           [[ -n "${{ steps.manifests-debug.outputs.text }}" ]] || (echo "No text" && exit 1)
+          echo 3
           [[ -n "$JSON" == "${{ steps.manifests-debug.outputs.json }}" ]] || (echo "Different JSON :/" && exit 1)
+          echo 4
       - run: |
+          echo 5
           JSON='{
             "isProduction": false,
             "manifests": [

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -12,49 +12,51 @@ jobs:
         with:
           path: ./k8s-manifests-debug/sample.yml
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "json output exist"
+        run: |
+          [[ -n "${{ steps.manifests-debug.outputs.json }}" ]] || (echo "No json" && exit 1)
+
       - name: "markdown output exist"
         run: |
           [[ -n "${{ steps.manifests-debug.outputs.markdown }}" ]] || (echo "No markdown" && exit 1)
 
-      - name: "text output exist"
+      - name: "text output is correct"
         run: |
-          [[ -n "${{ steps.manifests-debug.outputs.text }}" ]] || (echo "No text" && exit 1)
+          TEXT='### Ingresses
 
-      - name: "json output is correct"
-        run: |
-          JSON='{
-            isProduction: false,
-            manifests: [
-              {
-                kind: Deployment,
-                name: nginx-deployment
-              },
-              {
-                kind: Service,
-                name: nginx
-              },
-              {
-                kind: Ingress,
-                name: example-ingress
-              }
-            ],
-            hosts: [
-              hello-world.info
-            ],
-            images: [
-              nginx:1.14.2
-            ]
-          }'
+          - 🚀 https://hello-world.info
 
-          if [[ "${JSON}" != "${{ steps.manifests-debug.outputs.json }}" ]]; then
+          ### Docker images
+
+          - 📦 docker pull nginx:1.14.2
+
+          ### Debug
+
+          #### 📕 Loki logs for namespace undefined:
+
+          https://grafana.fabrique.social.gouv.fr/explore?orgId=1&left=%5B%22now-6h%22,%22now%22,%22Loki-tail%22,%7B%22expr%22:%22%7Bnamespace%3D%5C%22undefined%5C%22%7D%22%7D%5D
+
+          #### 📈 Pods monitoring for namespace undefined:
+
+          https://grafana.fabrique.social.gouv.fr/d/85a562078cdf77779eaa1add43ccec1e/kubernetes-compute-resources-namespace-pods?orgId=1&refresh=10s&var-datasource=default&var-cluster=dev2&var-namespace=undefined
+
+          #### 📈 Workloads monitoring for namespace undefined:
+
+          https://grafana.fabrique.social.gouv.fr/d/a87fb0d919ec0ea5f6543124e16c42a5/kubernetes-compute-resources-namespace-workloads?orgId=1&refresh=10s&var-datasource=default&var-cluster=dev2&var-namespace=undefined&var-type=deployment
+
+          #### 👮‍♂️ Rancher project undefined:
+
+          https://rancher.fabrique.social.gouv.fr/p//workloads'
+
+          if [[ "${TEXT}" != "${{ steps.manifests-debug.outputs.text }}" ]]; then
             echo "------------------"
-            echo "Invalid JSON"
+            echo "Invalid TEXT"
             echo "-"
             echo "Expected:"
-            echo "${JSON}"
+            echo "${TEXT}"
             echo "---"
             echo "Actual:"
-            echo "${{ steps.manifests-debug.outputs.json }}"
+            echo "${{ steps.manifests-debug.outputs.text }}"
             echo "------------------"
             exit 1
           fi

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -12,6 +12,6 @@ jobs:
           path: ./k8s-manifests-debug/sample.yml
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
-        echo ${{ steps.test.outputs.markdown }}
-        echo ${{ steps.test.outputs.text }}
-        echo ${{ steps.test.outputs.json }}
+          echo ${{ steps.test.outputs.markdown }}
+          echo ${{ steps.test.outputs.text }}
+          echo ${{ steps.test.outputs.json }}

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -13,6 +13,35 @@ jobs:
           path: ./k8s-manifests-debug/sample.yml
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
-          echo "${{ steps.manifests-debug.outputs.markdown }}"
-          echo "${{ steps.manifests-debug.outputs.text }}"
-          echo "${{ steps.manifests-debug.outputs.json }}"
+          [[ -n "${{ steps.manifests-debug.outputs.markdown }}" ]] || (echo "No markdown" && exit 1)
+          [[ -n "${{ steps.manifests-debug.outputs.text }}" ]] || (echo "No text" && exit 1)
+          [[ "$JSON" == "${{ steps.manifests-debug.outputs.json }}" ]] || (echo "Different JSON :/" && exit 1)
+      - run: |
+          JSON='{
+            "isProduction": false,
+            "manifests": [
+              {
+                "kind": "Deployment",
+                "name": "nginx-deployment"
+              },
+              {
+                "kind": "Service",
+                "name": "nginx"
+              },
+              {
+                "kind": "Ingress",
+                "name": "example-ingress"
+              }
+            ],
+            "hosts": [
+              "hello-world.info"
+            ],
+            "images": [
+              "nginx:1.14.2"
+            ]
+          }'
+          if [[ "$JSON" != "${{ steps.manifests-debug.outputs.json }}" ]]; then
+            echo "Invalid JSON"
+            echo "${{ steps.manifests-debug.outputs.json }}"
+            exit 1
+          fi

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -3,7 +3,7 @@ on: [push]
 jobs:
   k8s-manifests-debug:
     runs-on: ubuntu-latest
-    name: k8s-manifests-debug
+    name: k8s-manifests-debug tests
     steps:
       - uses: actions/checkout@v2
       - id: manifests-debug
@@ -12,13 +12,16 @@ jobs:
         with:
           path: ./k8s-manifests-debug/sample.yml
           token: ${{ secrets.GITHUB_TOKEN }}
-      - run: |
+      - name: "markdown output exist"
+        run: |
           [[ -n "${{ steps.manifests-debug.outputs.markdown }}" ]] || (echo "No markdown" && exit 1)
 
-      - run: |
+      - name: "text output exist"
+        run: |
           [[ -n "${{ steps.manifests-debug.outputs.text }}" ]] || (echo "No text" && exit 1)
 
-      - run: |
+      - name: "json output is correct"
+        run: |
           echo 3
           JSON='{
             "isProduction": false,

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: wget https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/master/release/kubernetes-manifests.yaml
       - id: test
-        uses: ../k8s-manifests-debug
+        uses: ./../k8s-manifests-debug
         with:
-          manifests: kubernetes-manifests.yaml
+          manifests: kubernetes-man ifests.yaml
       - run: echo ${{ steps.test.outputs.markdown }}

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -12,6 +12,8 @@ jobs:
         with:
           path: ./k8s-manifests-debug/sample.yml
           token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          HELLO: WORLD
       - name: "json output exist"
         run: |
           [[ -n "${{ steps.manifests-debug.outputs.json }}" ]] || (echo "No json" && exit 1)

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -6,12 +6,13 @@ jobs:
     name: k8s-manifests-debug
     steps:
       - uses: actions/checkout@v2
-      - id: test
+      - id: manifests-debug
+        name: "⛑️ Debug Manifests ⛑️ "
         uses: ./k8s-manifests-debug
         with:
           path: ./k8s-manifests-debug/sample.yml
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: |
-          echo ${{ steps.test.outputs.markdown }}
-          echo ${{ steps.test.outputs.text }}
-          echo ${{ steps.test.outputs.json }}
+          echo ${{ steps.manifests-debug.outputs.markdown }}
+          echo ${{ steps.manifests-debug.outputs.text }}
+          echo ${{ steps.manifests-debug.outputs.json }}

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -15,7 +15,7 @@ jobs:
       - run: |
           [[ -n "${{ steps.manifests-debug.outputs.markdown }}" ]] || (echo "No markdown" && exit 1)
           [[ -n "${{ steps.manifests-debug.outputs.text }}" ]] || (echo "No text" && exit 1)
-          [[ "$JSON" == "${{ steps.manifests-debug.outputs.json }}" ]] || (echo "Different JSON :/" && exit 1)
+          [[ -n "$JSON" == "${{ steps.manifests-debug.outputs.json }}" ]] || (echo "Different JSON :/" && exit 1)
       - run: |
           JSON='{
             "isProduction": false,

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -10,6 +10,6 @@ jobs:
       - id: test
         uses: ./k8s-manifests-debug
         with:
-          manifests: kubernetes-manifests.yaml
+          path: kubernetes-manifests.yaml
           token: ${{ secrets.GITHUB_TOKEN }}
       - run: echo ${{ steps.test.outputs.markdown }}

--- a/.github/workflows/k8s-manifests-debug-test.yaml
+++ b/.github/workflows/k8s-manifests-debug-test.yaml
@@ -22,38 +22,39 @@ jobs:
 
       - name: "json output is correct"
         run: |
-          echo 3
           JSON='{
-            "isProduction": false,
-            "manifests": [
+            isProduction: false,
+            manifests: [
               {
-                "kind": "Deployment",
-                "name": "nginx-deployment"
+                kind: Deployment,
+                name: nginx-deployment
               },
               {
-                "kind": "Service",
-                "name": "nginx"
+                kind: Service,
+                name: nginx
               },
               {
-                "kind": "Ingress",
-                "name": "example-ingress"
+                kind: Ingress,
+                name: example-ingress
               }
             ],
-            "hosts": [
-              "hello-world.info"
+            hosts: [
+              hello-world.info
             ],
-            "images": [
-              "nginx:1.14.2"
+            images: [
+              nginx:1.14.2
             ]
           }'
 
           if [[ "${JSON}" != "${{ steps.manifests-debug.outputs.json }}" ]]; then
-            echo "---"
+            echo "------------------"
             echo "Invalid JSON"
+            echo "-"
+            echo "Expected:"
             echo "${JSON}"
             echo "---"
+            echo "Actual:"
             echo "${{ steps.manifests-debug.outputs.json }}"
-            echo "---"
-            echo "${{ steps.manifests-debug.outputs.json }}"
+            echo "------------------"
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # actions
+
 The SocialGouv Github Actions
+
+## socialgouv/actions/k8s-manifests-debug
+
+- Display useful informations from your kubernetes manifests in the job log
+- Post a comment with the same informations on related PR
+- expose a `markdown` output with same content
+
+```yaml
+- uses: socialgouv/actions/k8s-manifests-debug
+  with:
+    path: kubernetes-manifests.yaml
+    token: ${{ secrets.GITHUB_TOKEN }}
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The SocialGouv Github Actions
 
 ## `socialgouv/actions/k8s-manifests-debug`
 
-- Display [useful informations from your kubernetes manifests](https://github.com/SocialGouv/sre-tools/tree/master/packages/parse-manifests) in the job log
+- Display [useful informations from your kubernetes manifests](https://github.com/SocialGouv/sre-tools/tree/master/packages/parse-manifests) in action log
 - Post a sticky comment in associated PR
 - Outputs : `markdown`, `json`, `text` variables
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The SocialGouv Github Actions
     path: kubernetes-manifests.yaml
     token: ${{ secrets.GITHUB_TOKEN }}
   env:
-    RANCHER_PROJECT_ID: some-project-id
+    RANCHER_PROJECT_ID: some-project-id # to provide a decent rancher url
 ```
 
 see [.github/workflows/k8s-manifests-debug-test.yaml](.github/workflows/k8s-manifests-debug-test.yaml)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ The SocialGouv Github Actions
 
 ## socialgouv/actions/k8s-manifests-debug
 
-- Display useful informations from your kubernetes manifests in the job log
-- Post a comment with the same informations on related PR
-- expose a `markdown` output with same content
+- Display [useful informations from your kubernetes manifests](https://github.com/SocialGouv/sre-tools/tree/master/packages/parse-manifests) in the job log
+- Post a sticky comment in associated PR
+- Outputs : `markdown`, `json`, `text`
 
 ```yaml
 - uses: socialgouv/actions/k8s-manifests-debug
@@ -14,3 +14,5 @@ The SocialGouv Github Actions
     path: kubernetes-manifests.yaml
     token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+see [.github/workflows/k8s-manifests-debug-test.yaml](.github/workflows/k8s-manifests-debug-test.yaml)

--- a/README.md
+++ b/README.md
@@ -2,17 +2,19 @@
 
 The SocialGouv Github Actions
 
-## socialgouv/actions/k8s-manifests-debug
+## `socialgouv/actions/k8s-manifests-debug`
 
 - Display [useful informations from your kubernetes manifests](https://github.com/SocialGouv/sre-tools/tree/master/packages/parse-manifests) in the job log
 - Post a sticky comment in associated PR
-- Outputs : `markdown`, `json`, `text`
+- Outputs : `markdown`, `json`, `text` variables
 
 ```yaml
 - uses: socialgouv/actions/k8s-manifests-debug
   with:
     path: kubernetes-manifests.yaml
     token: ${{ secrets.GITHUB_TOKEN }}
+  env:
+    RANCHER_PROJECT_ID: some-project-id
 ```
 
 see [.github/workflows/k8s-manifests-debug-test.yaml](.github/workflows/k8s-manifests-debug-test.yaml)

--- a/k8s-manifests-debug/action.yml
+++ b/k8s-manifests-debug/action.yml
@@ -28,6 +28,8 @@ runs:
         MARKDOWN=$(cat "${MANIFESTS}" | npx @socialgouv/parse-manifests --markdown)
         TEXT=$(cat "${MANIFESTS}" | npx @socialgouv/parse-manifests --text)
 
+        env 
+
         echo "${TEXT}"
 
         JSON="${JSON//$'\n'/'%0A'}"

--- a/k8s-manifests-debug/action.yml
+++ b/k8s-manifests-debug/action.yml
@@ -22,6 +22,7 @@ runs:
         pwd
         env
         echo "${MANIFESTS}"
+        cat "${MANIFESTS}"
         TEXT=$(cat manifests.yml | npx @socialgouv/parse-manifests --text)
         echo "${TEXT}"
         MARKDOWN=$(cat manifests.yml | npx @socialgouv/parse-manifests --markdown)

--- a/k8s-manifests-debug/action.yml
+++ b/k8s-manifests-debug/action.yml
@@ -3,6 +3,10 @@ description: "Debug some kubernetes manifests"
 inputs:
   manifests:
     description: "Your manifests YAML"
+  token:
+    description: "Github token for PR comment"
+  # env:
+  #   description: "Env for the parse-manifests phase"
 outputs:
   markdown:
     description: "Markdown debug"
@@ -16,7 +20,7 @@ runs:
         ls
         pwd
         env
-        echo "${MANIFESTS}""
+        echo "${MANIFESTS}"
         TEXT=$(cat manifests.yml | npx @socialgouv/parse-manifests --text)
         echo "${TEXT}"
         MARKDOWN=$(cat manifests.yml | npx @socialgouv/parse-manifests --markdown)
@@ -24,7 +28,7 @@ runs:
         MARKDOWN="${MARKDOWN//$'\r'/'%0D'}"
         echo "::set-output name=markdown::$MARKDOWN"
       env:
-        RANCHER_PROJECT_ID: ${{ secrets.RANCHER_PROJECT_ID }}
+        #RANCHER_PROJECT_ID: ${{ secrets.RANCHER_PROJECT_ID }}
         MANIFESTS: ${{ inputs.manifests }}
 
     # necessary to find the PR on push events
@@ -38,4 +42,4 @@ runs:
         message: |
           Deployment ${{ github.sha }}.
           ${{ steps.debug-manifests.outputs.markdown }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.token }}

--- a/k8s-manifests-debug/action.yml
+++ b/k8s-manifests-debug/action.yml
@@ -2,7 +2,7 @@ name: "⛑ Debug manifests ⛑"
 description: "Debug some kubernetes manifests"
 inputs:
   path:
-    description: "Your manifests YAML"
+    description: "Your manifests YAML file path"
   token:
     description: "Github token for PR comment"
   # env:
@@ -18,6 +18,7 @@ runs:
       shell: bash
       id: debug-manifests
       run: |
+        cat "${MANIFESTS}"
         TEXT=$(cat "${MANIFESTS}" | npx @socialgouv/parse-manifests --text)
         echo "${TEXT}"
         MARKDOWN=$(cat "${MANIFESTS}" | npx @socialgouv/parse-manifests --markdown)

--- a/k8s-manifests-debug/action.yml
+++ b/k8s-manifests-debug/action.yml
@@ -1,0 +1,41 @@
+name: "⛑ Debug manifests ⛑"
+description: "Debug some kubernetes manifests"
+inputs:
+  manifests:
+    description: "Your manifests YAML"
+outputs:
+  markdown:
+    description: "Markdown debug"
+    value: ${{ steps.debug-manifests.outputs.markdown }}
+runs:
+  using: "composite"
+  steps:
+    - name: ⛑ Debug manifests ⛑
+      id: debug-manifests
+      run: |
+        ls
+        pwd
+        env
+        echo "${MANIFESTS}""
+        TEXT=$(cat manifests.yml | npx @socialgouv/parse-manifests --text)
+        echo "${TEXT}"
+        MARKDOWN=$(cat manifests.yml | npx @socialgouv/parse-manifests --markdown)
+        MARKDOWN="${MARKDOWN//$'\n'/'%0A'}"
+        MARKDOWN="${MARKDOWN//$'\r'/'%0D'}"
+        echo "::set-output name=markdown::$MARKDOWN"
+      env:
+        RANCHER_PROJECT_ID: ${{ secrets.RANCHER_PROJECT_ID }}
+        MANIFESTS: ${{ inputs.manifests }}
+
+    # necessary to find the PR on push events
+    - uses: jwalton/gh-find-current-pr@v1
+      id: finder
+
+    - name: ⛑ Comment PR
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        number: ${{ steps.finder.outputs.pr }}
+        message: |
+          Deployment ${{ github.sha }}.
+          ${{ steps.debug-manifests.outputs.markdown }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/k8s-manifests-debug/action.yml
+++ b/k8s-manifests-debug/action.yml
@@ -18,8 +18,6 @@ runs:
       shell: bash
       id: debug-manifests
       run: |
-        ls
-        pwd
         cat "${MANIFESTS}"
         TEXT=$(cat "${MANIFESTS}" | npx @socialgouv/parse-manifests --text)
         echo "${TEXT}"

--- a/k8s-manifests-debug/action.yml
+++ b/k8s-manifests-debug/action.yml
@@ -52,6 +52,6 @@ runs:
       with:
         number: ${{ steps.finder.outputs.pr }}
         message: |
-          Deployment ${{ github.sha }}.
+          🎉 Deployment for commit ${{ github.sha }} :
           ${{ steps.debug-manifests.outputs.markdown }}
         GITHUB_TOKEN: ${{ inputs.token }}

--- a/k8s-manifests-debug/action.yml
+++ b/k8s-manifests-debug/action.yml
@@ -14,7 +14,8 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: ⛑ Debug manifests ⛑
+    - name: Debug manifests
+      shell: bash
       id: debug-manifests
       run: |
         ls

--- a/k8s-manifests-debug/action.yml
+++ b/k8s-manifests-debug/action.yml
@@ -8,9 +8,15 @@ inputs:
   # env:
   #   description: "Env for the parse-manifests phase"
 outputs:
+  json:
+    description: "Json debug"
+    value: ${{ steps.debug-manifests.outputs.json }}
   markdown:
     description: "Markdown debug"
     value: ${{ steps.debug-manifests.outputs.markdown }}
+  text:
+    description: "Text debug"
+    value: ${{ steps.debug-manifests.outputs.text }}
 runs:
   using: "composite"
   steps:
@@ -18,13 +24,22 @@ runs:
       shell: bash
       id: debug-manifests
       run: |
-        cat "${MANIFESTS}"
-        TEXT=$(cat "${MANIFESTS}" | npx @socialgouv/parse-manifests --text)
-        echo "${TEXT}"
+        JSON=$(cat "${MANIFESTS}" | npx @socialgouv/parse-manifests --json)
         MARKDOWN=$(cat "${MANIFESTS}" | npx @socialgouv/parse-manifests --markdown)
+        TEXT=$(cat "${MANIFESTS}" | npx @socialgouv/parse-manifests --text)
+
+        echo "${TEXT}"
+
+        JSON="${JSON//$'\n'/'%0A'}"
+        JSON="${JSON//$'\r'/'%0D'}"
         MARKDOWN="${MARKDOWN//$'\n'/'%0A'}"
         MARKDOWN="${MARKDOWN//$'\r'/'%0D'}"
+        TEXT="${TEXT//$'\n'/'%0A'}"
+        TEXT="${TEXT//$'\r'/'%0D'}"
+
+        echo "::set-output name=json::$JSON"
         echo "::set-output name=markdown::$MARKDOWN"
+        echo "::set-output name=text::$TEXT"
       env:
         MANIFESTS: ${{ inputs.path }}
 

--- a/k8s-manifests-debug/action.yml
+++ b/k8s-manifests-debug/action.yml
@@ -18,6 +18,8 @@ runs:
       shell: bash
       id: debug-manifests
       run: |
+        ls
+        pwd
         cat "${MANIFESTS}"
         TEXT=$(cat "${MANIFESTS}" | npx @socialgouv/parse-manifests --text)
         echo "${TEXT}"

--- a/k8s-manifests-debug/action.yml
+++ b/k8s-manifests-debug/action.yml
@@ -28,8 +28,6 @@ runs:
         MARKDOWN=$(cat "${MANIFESTS}" | npx @socialgouv/parse-manifests --markdown)
         TEXT=$(cat "${MANIFESTS}" | npx @socialgouv/parse-manifests --text)
 
-        env 
-
         echo "${TEXT}"
 
         JSON="${JSON//$'\n'/'%0A'}"

--- a/k8s-manifests-debug/action.yml
+++ b/k8s-manifests-debug/action.yml
@@ -1,7 +1,7 @@
 name: "⛑ Debug manifests ⛑"
 description: "Debug some kubernetes manifests"
 inputs:
-  manifests:
+  path:
     description: "Your manifests YAML"
   token:
     description: "Github token for PR comment"
@@ -18,20 +18,14 @@ runs:
       shell: bash
       id: debug-manifests
       run: |
-        ls
-        pwd
-        env
-        echo "${MANIFESTS}"
-        cat "${MANIFESTS}"
-        TEXT=$(cat manifests.yml | npx @socialgouv/parse-manifests --text)
+        TEXT=$(cat "${MANIFESTS}" | npx @socialgouv/parse-manifests --text)
         echo "${TEXT}"
-        MARKDOWN=$(cat manifests.yml | npx @socialgouv/parse-manifests --markdown)
+        MARKDOWN=$(cat "${MANIFESTS}" | npx @socialgouv/parse-manifests --markdown)
         MARKDOWN="${MARKDOWN//$'\n'/'%0A'}"
         MARKDOWN="${MARKDOWN//$'\r'/'%0D'}"
         echo "::set-output name=markdown::$MARKDOWN"
       env:
-        #RANCHER_PROJECT_ID: ${{ secrets.RANCHER_PROJECT_ID }}
-        MANIFESTS: ${{ inputs.manifests }}
+        MANIFESTS: ${{ inputs.path }}
 
     # necessary to find the PR on push events
     - uses: jwalton/gh-find-current-pr@v1

--- a/k8s-manifests-debug/sample.yml
+++ b/k8s-manifests-debug/sample.yml
@@ -1,0 +1,52 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2 # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+  selector:
+    app: nginx
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-ingress
+spec:
+  rules:
+    - host: hello-world.info
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: nginx
+                port:
+                  number: 80

--- a/k8s-manifests-debug/sample.yml
+++ b/k8s-manifests-debug/sample.yml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
+  namespace: some-namespace
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
## `socialgouv/actions/k8s-manifests-debug`

- Display [useful informations from your kubernetes manifests](https://github.com/SocialGouv/sre-tools/tree/master/packages/parse-manifests) in the job log
- Post a sticky comment in associated PR
- Outputs : `markdown`, `json`, `text` variables

```yaml
- uses: socialgouv/actions/k8s-manifests-debug
  with:
    path: kubernetes-manifests.yaml
    token: ${{ secrets.GITHUB_TOKEN }}
  env:
    RANCHER_PROJECT_ID: some-project-id # to provide a decent rancher url
```

see [.github/workflows/k8s-manifests-debug-test.yaml](.github/workflows/k8s-manifests-debug-test.yaml)

![](https://media.giphy.com/media/RqctLj8o9jkKZALsHj/giphy.gif?cid=ecf05e47rdupwbhm6w4vbehyjz9nd17j04wc3dzaxbi5bunp&rid=giphy.gif&ct=g)