### PR TITLE
fix(k8s-manifests): yarn cache for .k8s

### DIFF
--- a/k8s-manifests/action.yml
+++ b/k8s-manifests/action.yml
@@ -18,6 +18,8 @@ runs:
 
       - name: Yarn cache setup
         uses: c-hive/gha-yarn-cache@v2
+        with:
+          directory: .k8s
 
       - name: Install kosko-charts dependencies
         shell: bash


### PR DESCRIPTION
looks like this is needed to use .k8s/yarn.lock

also, this fails when there is no yarn.lock in the repo root