### PR TITLE
feat(autodevops-manifests): add inputs.rancherId

### DIFF
--- a/autodevops-deploy/action.yml
+++ b/autodevops-deploy/action.yml
@@ -38,7 +38,9 @@ runs:
     - name: Get project and namespace names
       shell: bash
       run: |
-        cat ".github/${{ inputs.environment }}.env" >> $GITHUB_ENV
+        if test -f ".github/${{ inputs.environment }}.env"; then
+          cat ".github/${{ inputs.environment }}.env" >> $GITHUB_ENV
+        fi
         echo "project=${GITHUB_REPOSITORY#*/}" >> $GITHUB_ENV
         echo "namespace=${NAMESPACE}" >> $GITHUB_ENV
       env:

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -3,15 +3,13 @@ description: "Generate k8s manifests via kosko-charts autodevops"
 inputs:
   environment:
     description: "The deployment environment (dev | preprod | prod)"
-    required: true
   productionNamespace:
     description: "Override production namesapce"
-  rancherProjectId:
-    description: "Rancher ID, usually secrets.RANCHER_PROJECT_ID"
-    required: true
-  socialgouvBaseDomain: 
-    description: "Base domain name, usually secrets.SOCIALGOUV_BASE_DOMAIN"
-    required: true
+  rancherId:
+    description: "The Rancher project ID, usually secrets.RANCHER_PROJECT_ID"
+  socialgouvBaseDomain:
+    description: "The base domain name, usually secrets.SOCIALGOUV_BASE_DOMAIN"
+
 runs:
   using: "composite"
   steps:
@@ -44,7 +42,7 @@ runs:
         yarn --cwd /tmp/autodevops --silent generate --env ${ENVIRONMENT} _namespace > namespace-${ENVIRONMENT}.yml
       env:
         ENVIRONMENT: ${{ inputs.environment }}
-        RANCHER_PROJECT_ID: ${{ inputs.rancherProjectId }}
+        RANCHER_PROJECT_ID: ${{ inputs.rancherId }}
         SOCIALGOUV_CONFIG_PATH: /tmp/autodevops/config.json
         SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain }}
         SOCIALGOUV_PRODUCTION_NAMESPACE: ${{ inputs.productionNamespace }}
@@ -58,7 +56,7 @@ runs:
         yarn --cwd /tmp/autodevops --silent generate --env ${ENVIRONMENT} > manifests-${ENVIRONMENT}.yml
       env:
         ENVIRONMENT: ${{ inputs.environment }}
-        RANCHER_PROJECT_ID: ${{ inputs.rancherProjectId }}
+        RANCHER_PROJECT_ID: ${{ inputs.rancherId }}
         SOCIALGOUV_CONFIG_PATH: /tmp/autodevops/config.json
         SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain }}
         SOCIALGOUV_PRODUCTION_NAMESPACE: ${{ inputs.productionNamespace }}

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -8,16 +8,21 @@ inputs:
     description: "Override production namesapce"
   rancherId:
     description: "The Rancher project ID, usually secrets.RANCHER_PROJECT_ID"
-    required: true
   socialgouvBaseDomain:
     description: "The base domain name, usually secrets.SOCIALGOUV_BASE_DOMAIN"
-    required: true
 
 runs:
   using: "composite"
   steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+
+    - name: Load environment variables
+      shell: bash
+      run: |
+        cat ".github/$ENVIRONMENT.env" >> $GITHUB_ENV
+      env:
+        ENVIRONMENT: ${{ inputs.environment }}
 
     - name: Yarn cache setup
       uses: c-hive/gha-yarn-cache@v1
@@ -45,9 +50,9 @@ runs:
         yarn --cwd /tmp/autodevops --silent generate --env ${ENVIRONMENT} _namespace > namespace-${ENVIRONMENT}.yml
       env:
         ENVIRONMENT: ${{ inputs.environment }}
-        RANCHER_PROJECT_ID: ${{ inputs.rancherId }}
+        RANCHER_PROJECT_ID: ${{ inputs.rancherId || env.RANCHER_PROJECT_ID }}
         SOCIALGOUV_CONFIG_PATH: /tmp/autodevops/config.json
-        SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain }}
+        SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain || env.SOCIALGOUV_BASE_DOMAIN }}
         SOCIALGOUV_PRODUCTION_NAMESPACE: ${{ inputs.productionNamespace }}
         SOCIALGOUV_PRODUCTION: ${{ inputs.environment == 'prod' && true || '' }}
         SOCIALGOUV_PREPRODUCTION: ${{ inputs.environment == 'preprod' && true || '' }}
@@ -59,9 +64,9 @@ runs:
         yarn --cwd /tmp/autodevops --silent generate --env ${ENVIRONMENT} > manifests-${ENVIRONMENT}.yml
       env:
         ENVIRONMENT: ${{ inputs.environment }}
-        RANCHER_PROJECT_ID: ${{ inputs.rancherId }}
+        RANCHER_PROJECT_ID: ${{ inputs.rancherId|| env.RANCHER_PROJECT_ID }}
         SOCIALGOUV_CONFIG_PATH: /tmp/autodevops/config.json
-        SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain }}
+        SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain || env.SOCIALGOUV_BASE_DOMAIN }}
         SOCIALGOUV_PRODUCTION_NAMESPACE: ${{ inputs.productionNamespace }}
         SOCIALGOUV_PRODUCTION: ${{ inputs.environment == 'prod' && true || '' }}
         SOCIALGOUV_PREPRODUCTION: ${{ inputs.environment == 'preprod' && true || '' }}

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -7,6 +7,8 @@ inputs:
     description: "Override production namesapce"
   rancherProjectId:
     description: "Rancher ID, usually secrets.RANCHER_PROJECT_ID"
+  socialgouvBaseDomain: 
+    description: "Base domain name, usually secrets.SOCIALGOUV_BASE_DOMAIN"
 runs:
   using: "composite"
   steps:
@@ -41,7 +43,7 @@ runs:
         ENVIRONMENT: ${{ inputs.environment }}
         RANCHER_PROJECT_ID: ${{ inputs.rancherProjectId }}
         SOCIALGOUV_CONFIG_PATH: /tmp/autodevops/config.json
-        SOCIALGOUV_BASE_DOMAIN: ${{ env.SOCIALGOUV_BASE_DOMAIN }}
+        SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain }}
         SOCIALGOUV_PRODUCTION_NAMESPACE: ${{ inputs.productionNamespace }}
         SOCIALGOUV_PRODUCTION: ${{ inputs.environment == 'prod' && true || '' }}
         SOCIALGOUV_PREPRODUCTION: ${{ inputs.environment == 'preprod' && true || '' }}
@@ -55,7 +57,7 @@ runs:
         ENVIRONMENT: ${{ inputs.environment }}
         RANCHER_PROJECT_ID: ${{ inputs.rancherProjectId }}
         SOCIALGOUV_CONFIG_PATH: /tmp/autodevops/config.json
-        SOCIALGOUV_BASE_DOMAIN: ${{ env.SOCIALGOUV_BASE_DOMAIN }}
+        SOCIALGOUV_BASE_DOMAIN: ${{ inputs.inputs.socialgouvBaseDomain }}
         SOCIALGOUV_PRODUCTION_NAMESPACE: ${{ inputs.productionNamespace }}
         SOCIALGOUV_PRODUCTION: ${{ inputs.environment == 'prod' && true || '' }}
         SOCIALGOUV_PREPRODUCTION: ${{ inputs.environment == 'preprod' && true || '' }}

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -20,7 +20,9 @@ runs:
     - name: Load environment variables
       shell: bash
       run: |
-        cat ".github/$ENVIRONMENT.env" >> $GITHUB_ENV
+        if test -f ".github/$ENVIRONMENT.env"; then
+          cat ".github/$ENVIRONMENT.env" >> $GITHUB_ENV
+        fi
       env:
         ENVIRONMENT: ${{ inputs.environment }}
 

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -57,7 +57,7 @@ runs:
         ENVIRONMENT: ${{ inputs.environment }}
         RANCHER_PROJECT_ID: ${{ inputs.rancherProjectId }}
         SOCIALGOUV_CONFIG_PATH: /tmp/autodevops/config.json
-        SOCIALGOUV_BASE_DOMAIN: ${{ inputs.inputs.socialgouvBaseDomain }}
+        SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain }}
         SOCIALGOUV_PRODUCTION_NAMESPACE: ${{ inputs.productionNamespace }}
         SOCIALGOUV_PRODUCTION: ${{ inputs.environment == 'prod' && true || '' }}
         SOCIALGOUV_PREPRODUCTION: ${{ inputs.environment == 'preprod' && true || '' }}

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -20,11 +20,9 @@ runs:
     - name: Load environment variables
       shell: bash
       run: |
-        if test -f ".github/$ENVIRONMENT.env"; then
-          cat ".github/$ENVIRONMENT.env" >> $GITHUB_ENV
+        if test -f ".github/${{ inputs.environment }}.env"; then
+          cat ".github/${{ inputs.environment }}.env" >> $GITHUB_ENV
         fi
-      env:
-        ENVIRONMENT: ${{ inputs.environment }}
 
     - name: Yarn cache setup
       uses: c-hive/gha-yarn-cache@v1

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -5,19 +5,13 @@ inputs:
     description: "The deployment environment (dev | preprod | prod)"
   productionNamespace:
     description: "Override production namesapce"
-
+  rancherProjectId:
+    description: "Rancher ID, usually secrets.RANCHER_PROJECT_ID"
 runs:
   using: "composite"
   steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-
-    - name: Load environment variables
-      shell: bash
-      run: |
-        cat ".github/$ENVIRONMENT.env" >> $GITHUB_ENV
-      env:
-        ENVIRONMENT: ${{ inputs.environment }}
 
     - name: Yarn cache setup
       uses: c-hive/gha-yarn-cache@v1
@@ -45,7 +39,7 @@ runs:
         yarn --cwd /tmp/autodevops --silent generate --env ${ENVIRONMENT} _namespace > namespace-${ENVIRONMENT}.yml
       env:
         ENVIRONMENT: ${{ inputs.environment }}
-        RANCHER_PROJECT_ID: ${{ env.RANCHER_PROJECT_ID }}
+        RANCHER_PROJECT_ID: ${{ inputs.rancherProjectId }}
         SOCIALGOUV_CONFIG_PATH: /tmp/autodevops/config.json
         SOCIALGOUV_BASE_DOMAIN: ${{ env.SOCIALGOUV_BASE_DOMAIN }}
         SOCIALGOUV_PRODUCTION_NAMESPACE: ${{ inputs.productionNamespace }}
@@ -59,7 +53,7 @@ runs:
         yarn --cwd /tmp/autodevops --silent generate --env ${ENVIRONMENT} > manifests-${ENVIRONMENT}.yml
       env:
         ENVIRONMENT: ${{ inputs.environment }}
-        RANCHER_PROJECT_ID: ${{ env.RANCHER_PROJECT_ID }}
+        RANCHER_PROJECT_ID: ${{ inputs.rancherProjectId }}
         SOCIALGOUV_CONFIG_PATH: /tmp/autodevops/config.json
         SOCIALGOUV_BASE_DOMAIN: ${{ env.SOCIALGOUV_BASE_DOMAIN }}
         SOCIALGOUV_PRODUCTION_NAMESPACE: ${{ inputs.productionNamespace }}

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -3,12 +3,15 @@ description: "Generate k8s manifests via kosko-charts autodevops"
 inputs:
   environment:
     description: "The deployment environment (dev | preprod | prod)"
+    required: true
   productionNamespace:
     description: "Override production namesapce"
   rancherId:
     description: "The Rancher project ID, usually secrets.RANCHER_PROJECT_ID"
+    required: true
   socialgouvBaseDomain:
     description: "The base domain name, usually secrets.SOCIALGOUV_BASE_DOMAIN"
+    required: true
 
 runs:
   using: "composite"

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -64,7 +64,7 @@ runs:
         yarn --cwd /tmp/autodevops --silent generate --env ${ENVIRONMENT} > manifests-${ENVIRONMENT}.yml
       env:
         ENVIRONMENT: ${{ inputs.environment }}
-        RANCHER_PROJECT_ID: ${{ inputs.rancherId|| env.RANCHER_PROJECT_ID }}
+        RANCHER_PROJECT_ID: ${{ inputs.rancherId || env.RANCHER_PROJECT_ID }}
         SOCIALGOUV_CONFIG_PATH: /tmp/autodevops/config.json
         SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain || env.SOCIALGOUV_BASE_DOMAIN }}
         SOCIALGOUV_PRODUCTION_NAMESPACE: ${{ inputs.productionNamespace }}

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -3,12 +3,15 @@ description: "Generate k8s manifests via kosko-charts autodevops"
 inputs:
   environment:
     description: "The deployment environment (dev | preprod | prod)"
+    required: true
   productionNamespace:
     description: "Override production namesapce"
   rancherProjectId:
     description: "Rancher ID, usually secrets.RANCHER_PROJECT_ID"
+    required: true
   socialgouvBaseDomain: 
     description: "Base domain name, usually secrets.SOCIALGOUV_BASE_DOMAIN"
+    required: true
 runs:
   using: "composite"
   steps:

--- a/k8s-manifests/action.yml
+++ b/k8s-manifests/action.yml
@@ -3,6 +3,7 @@ description: "Generate k8s manifests based on .k8s folder"
 inputs:
   environment:
     description: "The deployment environment (dev | preprod | prod)"
+    required: true
   rancherId:
     description: "Rancher ID, usually secrets.RANCHER_PROJECT_ID"
     required: true

--- a/k8s-manifests/action.yml
+++ b/k8s-manifests/action.yml
@@ -6,10 +6,8 @@ inputs:
     required: true
   rancherId:
     description: "Rancher ID, usually secrets.RANCHER_PROJECT_ID"
-    required: true
   socialgouvBaseDomain: 
     description: "Base domain name, usually secrets.SOCIALGOUV_BASE_DOMAIN"
-    required: true
 runs:
   using: "composite"
   steps:

--- a/k8s-manifests/action.yml
+++ b/k8s-manifests/action.yml
@@ -17,6 +17,11 @@ runs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Load review environment variables
+        shell: bash
+        run: |
+          cat ".github/${{ inputs.environment }}.env" >> $GITHUB_ENV
+
       - name: Yarn cache setup
         uses: c-hive/gha-yarn-cache@v2
         with:
@@ -30,8 +35,8 @@ runs:
         shell: bash
         run: yarn --cwd .k8s --silent generate --env ${{ inputs.environment }} > manifests-${{ inputs.environment }}.yml
         env:
-          RANCHER_PROJECT_ID: ${{ inputs.rancherId }}
-          SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain }}
+          RANCHER_PROJECT_ID: ${{ inputs.rancherId || env.RANCHER_PROJECT_ID }}
+          SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain || env.SOCIALGOUV_BASE_DOMAIN }}
           SOCIALGOUV_PRODUCTION: ${{ inputs.environment == 'prod' && true || '' }}
           SOCIALGOUV_PREPRODUCTION: ${{ inputs.environment == 'preprod' && true || '' }}
 
@@ -39,8 +44,8 @@ runs:
         shell: bash
         run: yarn --cwd .k8s --silent generate --env ${{ inputs.environment }} _namespace > namespace-${{ inputs.environment }}.yml
         env:
-          RANCHER_PROJECT_ID: ${{ inputs.rancherId }}
-          SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain }}
+          RANCHER_PROJECT_ID: ${{ inputs.rancherId || env.RANCHER_PROJECT_ID }}
+          SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain || env.SOCIALGOUV_BASE_DOMAIN }}
           SOCIALGOUV_PRODUCTION: ${{ inputs.environment == 'prod' && true || '' }}
           SOCIALGOUV_PREPRODUCTION: ${{ inputs.environment == 'preprod' && true || '' }}
 

--- a/k8s-manifests/action.yml
+++ b/k8s-manifests/action.yml
@@ -18,7 +18,9 @@ runs:
       - name: Load review environment variables
         shell: bash
         run: |
-          cat ".github/${{ inputs.environment }}.env" >> $GITHUB_ENV
+          if test -f ".github/${{ inputs.environment }}.env"; then
+            cat ".github/${{ inputs.environment }}.env" >> $GITHUB_ENV
+          fi
 
       - name: Yarn cache setup
         uses: c-hive/gha-yarn-cache@v2

--- a/k8s-manifests/action.yml
+++ b/k8s-manifests/action.yml
@@ -3,18 +3,16 @@ description: "Generate k8s manifests based on .k8s folder"
 inputs:
   environment:
     description: "The deployment environment (dev | preprod | prod)"
-
+  rancherProjectId:
+    description: "Rancher ID, usually secrets.RANCHER_PROJECT_ID"
+  socialgouvBaseDomain: 
+    description: "Base domain name, usually secrets.SOCIALGOUV_BASE_DOMAIN"
 runs:
   using: "composite"
   steps:
 
       - name: Checkout repository
         uses: actions/checkout@v2
-
-      - name: Load review environment variables
-        shell: bash
-        run: |
-          cat ".github/${{ inputs.environment }}.env" >> $GITHUB_ENV
 
       - name: Yarn cache setup
         uses: c-hive/gha-yarn-cache@v2
@@ -29,8 +27,8 @@ runs:
         shell: bash
         run: yarn --cwd .k8s --silent generate --env ${{ inputs.environment }} > manifests-${{ inputs.environment }}.yml
         env:
-          RANCHER_PROJECT_ID: ${{ env.RANCHER_PROJECT_ID }}
-          SOCIALGOUV_BASE_DOMAIN: ${{ env.SOCIALGOUV_BASE_DOMAIN }}
+          RANCHER_PROJECT_ID: ${{ inputs.rancherProjectId }}
+          SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain }}
           SOCIALGOUV_PRODUCTION: ${{ inputs.environment == 'prod' && true || '' }}
           SOCIALGOUV_PREPRODUCTION: ${{ inputs.environment == 'preprod' && true || '' }}
 
@@ -38,8 +36,8 @@ runs:
         shell: bash
         run: yarn --cwd .k8s --silent generate --env ${{ inputs.environment }} _namespace > namespace-${{ inputs.environment }}.yml
         env:
-          RANCHER_PROJECT_ID: ${{ env.RANCHER_PROJECT_ID }}
-          SOCIALGOUV_BASE_DOMAIN: ${{ env.SOCIALGOUV_BASE_DOMAIN }}
+          RANCHER_PROJECT_ID: ${{ inputs.rancherProjectId }}
+          SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain }}
           SOCIALGOUV_PRODUCTION: ${{ inputs.environment == 'prod' && true || '' }}
           SOCIALGOUV_PREPRODUCTION: ${{ inputs.environment == 'preprod' && true || '' }}
 

--- a/k8s-manifests/action.yml
+++ b/k8s-manifests/action.yml
@@ -3,7 +3,7 @@ description: "Generate k8s manifests based on .k8s folder"
 inputs:
   environment:
     description: "The deployment environment (dev | preprod | prod)"
-  rancherProjectId:
+  rancherId:
     description: "Rancher ID, usually secrets.RANCHER_PROJECT_ID"
     required: true
   socialgouvBaseDomain: 
@@ -29,7 +29,7 @@ runs:
         shell: bash
         run: yarn --cwd .k8s --silent generate --env ${{ inputs.environment }} > manifests-${{ inputs.environment }}.yml
         env:
-          RANCHER_PROJECT_ID: ${{ inputs.rancherProjectId }}
+          RANCHER_PROJECT_ID: ${{ inputs.rancherId }}
           SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain }}
           SOCIALGOUV_PRODUCTION: ${{ inputs.environment == 'prod' && true || '' }}
           SOCIALGOUV_PREPRODUCTION: ${{ inputs.environment == 'preprod' && true || '' }}
@@ -38,7 +38,7 @@ runs:
         shell: bash
         run: yarn --cwd .k8s --silent generate --env ${{ inputs.environment }} _namespace > namespace-${{ inputs.environment }}.yml
         env:
-          RANCHER_PROJECT_ID: ${{ inputs.rancherProjectId }}
+          RANCHER_PROJECT_ID: ${{ inputs.rancherId }}
           SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain }}
           SOCIALGOUV_PRODUCTION: ${{ inputs.environment == 'prod' && true || '' }}
           SOCIALGOUV_PREPRODUCTION: ${{ inputs.environment == 'preprod' && true || '' }}

--- a/k8s-manifests/action.yml
+++ b/k8s-manifests/action.yml
@@ -5,8 +5,10 @@ inputs:
     description: "The deployment environment (dev | preprod | prod)"
   rancherProjectId:
     description: "Rancher ID, usually secrets.RANCHER_PROJECT_ID"
+    required: true
   socialgouvBaseDomain: 
     description: "Base domain name, usually secrets.SOCIALGOUV_BASE_DOMAIN"
+    required: true
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
to discuss

 - add `rancherId` and `socialgouvBaseDomain` inputs to generate manifests actions. so we can use ops secrets instead of hardcoded `.env`
 - still use what's in `.github/[env].env` if not provided
 - allow generation without `.env` files

Usage : 

```yml
      - name: Use k8s manifests generation
        uses: SocialGouv/actions/k8s-manifests@v1
        with:
          environment: "dev"
          rancherId: ${{ secrets.RANCHER_PROJECT_ID }}
          socialgouvBaseDomain: ${{ secrets.SOCIALGOUV_BASE_DOMAIN }}
```