### PR TITLE
fix: Use local cache as a workaround to the blob not found issue

### DIFF
--- a/autodevops-build-register/action.yml
+++ b/autodevops-build-register/action.yml
@@ -57,6 +57,14 @@ runs:
         username: ${{ github.actor }}
         password: ${{ inputs.token }}
 
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-single-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-single-buildx
+
     - name: Image build and register
       uses: docker/build-push-action@v2
       with:
@@ -67,5 +75,13 @@ runs:
         build-args: ${{ inputs.dockerbuildargs }}
         tags: "${{ steps.docker_meta.outputs.tags }}"
         labels: "${{ steps.docker_meta.outputs.labels }}"
-        cache-from: "type=gha,scope=${{ inputs.imageName }}-cache"
-        cache-to: "type=gha,scope=${{ inputs.imageName }}-cache,mode=max"
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new
+        # cache-from: "type=gha,scope=${{ inputs.imageName }}-cache"
+        # cache-to: "type=gha,scope=${{ inputs.imageName }}-cache,mode=max"
+
+    - name: Move cache
+      shell: bash
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
Version of the `autodevops-build-register` action to be used only when you get a *blob not found* error while registering a package image.