### PR TITLE
fix(deactivate): run yarn cache in .k8s directory

### DIFF
--- a/k8s-deactivate/action.yml
+++ b/k8s-deactivate/action.yml
@@ -27,6 +27,8 @@ runs:
 
     - name: Yarn cache setup
       uses: c-hive/gha-yarn-cache@v1
+      with:
+        directory: .k8s
 
     - name: Install kosko-charts dependencies
       shell: bash


### PR DESCRIPTION
_This PR comment is in french_

Salut 👋  À moins que je ne me trompes, le `c-hive/gha-yarn-cache@v1` est exécuté à la racine du repo alors qu'il devrait l'être dans `.k8s`. En effet, rien ne dit qu'il y a un `yarn.lock` à la racine (et donc sans ce fix, l'action crash s'il n'y en a pas), ni même que le projet soit du JS. Et il me semble que l'objectif ici est de cacher le yarn de k8s pour faire ensuite le reste des steps.

DISCLAIMER : je n'ai peut-être rien compris, n'hésitez pas à fermer cette PR si je suis à côté de la plaque 😬 