### PR TITLE
feat: autodevops-manifests

### DIFF
--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -54,6 +54,10 @@ runs:
           echo "no socialgouv config.json or components found :/"
           exit 1
         fi
+        if [ -d ".socialgouv/__tests__" ]; then
+          echo "Copy tests"
+          cp -r .socialgouv/__tests__ $DEST/__tests__
+        fi
     - name: Install dependencies
       shell: bash
       run: |
@@ -65,8 +69,6 @@ runs:
       run: |
         if [ -d ".socialgouv/__tests__" ]; then
           echo "Run kosko manifests tests"
-          echo "Copy tests"
-          cp -r .socialgouv/__tests__ $DEST/__tests__
           yarn --cwd /tmp/autodevops test
         fi
 

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -60,10 +60,12 @@ runs:
         yarn --cwd /tmp/autodevops
 
     # For example
-    - name: Run kosko tests
+    - name: Run kosko manifests tests
       shell: bash
       run: |
-        yarn --cwd /tmp/autodevops test
+        if [ -f ".socialgouv/__tests__" ]; then
+          yarn --cwd /tmp/autodevops test
+        fi
 
     - name: Generate k8s namespace
       shell: bash

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -31,11 +31,6 @@ runs:
         rm -rf /tmp/autodevops/environments
 
     - name: Yarn cache setup
-      uses: c-hive/gha-yarn-cache@v1
-      with:
-        directory: /tmp/autodevops
-
-    - name: Yarn cache setup
       uses: c-hive/gha-yarn-cache@v2
       with:
         directory: /tmp/autodevops
@@ -57,6 +52,10 @@ runs:
         if [ -f ".socialgouv/config.json" ]; then
           echo "$ cp .socialgouv/config.json $DEST/"
           cp .socialgouv/config.json $DEST/
+        fi
+        if [ -f ".socialgouv/kosko.toml" ]; then
+          echo "$ cp .socialgouv/kosko.toml $DEST/"
+          cp .socialgouv/kosko.toml $DEST/
         fi
 
     - name: Install dependencies

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -39,21 +39,16 @@ runs:
           cp -r .socialgouv/environments $DEST/environments
         fi
         if [ -d ".socialgouv/components" ]; then
-          # use userland components instead of autodevops ones
-          echo "$ rm -rf $DEST/components;"
+          # use userland `.socialgouv` folder instead of autodevops template when `components` folder is found
+          echo "rm -rf $DEST/components"
           rm -rf $DEST/components
           echo "$ cp -r .socialgouv/* $DEST/"
           cp -r .socialgouv/* $DEST/
         fi
-        if [ -f ".socialgouv/config.json" ]; then
-          echo "$ cp .socialgouv/config.json $DEST/"
-          cp .socialgouv/config.json $DEST/
+        if [ -f ".socialgouv/config.json" ]; then	
+          echo "$ cp .socialgouv/config.json $DEST/"	
+          cp .socialgouv/config.json $DEST/	
         fi
-        if [ -f ".socialgouv/kosko.toml" ]; then
-          echo "$ cp .socialgouv/kosko.toml $DEST/"
-          cp .socialgouv/kosko.toml $DEST/
-        fi
-
     - name: Install dependencies
       shell: bash
       run: |
@@ -65,6 +60,8 @@ runs:
       run: |
         if [ -d ".socialgouv/__tests__" ]; then
           echo "Run kosko manifests tests"
+          echo "Copy tests"
+          cp -r .socialgouv/__tests__ $DEST/__tests__
           yarn --cwd /tmp/autodevops test
         fi
 

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -58,12 +58,12 @@ runs:
           echo "Copy tests"
           cp -r .socialgouv/__tests__ $DEST/__tests__
         fi
+
     - name: Install dependencies
       shell: bash
       run: |
         yarn --cwd /tmp/autodevops
 
-    # For example
     - name: Run kosko manifests tests
       shell: bash
       run: |

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -24,15 +24,16 @@ runs:
           cat ".github/${{ inputs.environment }}.env" >> $GITHUB_ENV
         fi
 
-    - name: Yarn cache setup
-      uses: c-hive/gha-yarn-cache@v1
-
-    - name: Install kosko-charts autodevops
+    - name: Degit autodevops template
       shell: bash
       run: |
         npx degit SocialGouv/kosko-charts/templates/autodevops /tmp/autodevops
         rm -rf /tmp/autodevops/environments
-        yarn --cwd /tmp/autodevops
+
+    - name: Yarn cache setup
+      uses: c-hive/gha-yarn-cache@v1
+      with:
+        directory: /tmp/autodevops
 
     - name: Copy application k8s config to autodevops
       shell: bash
@@ -41,8 +42,28 @@ runs:
           echo "$ cp -r .socialgouv/environments /tmp/autodevops/environments"
           cp -r .socialgouv/environments /tmp/autodevops/environments
         fi
-        echo "$ cp .socialgouv/config.json /tmp/autodevops/"
-        cp .socialgouv/config.json /tmp/autodevops/
+        if [ -d ".socialgouv/components" ]; then
+          # use userland components instead of autodevops ones
+          echo "$ rm -rf $DEST/components;"
+          rm -rf $DEST/components
+          echo "$ cp -r .socialgouv/* $DEST/"
+          cp -r .socialgouv/* $DEST/
+        fi
+        if [ -f ".socialgouv/config.json" ]; then
+          echo "$ cp .socialgouv/config.json $DEST/"
+          cp .socialgouv/config.json $DEST/
+        fi
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        yarn --cwd /tmp/autodevops
+
+    # For example
+    - name: Run kosko tests
+      shell: bash
+      run: |
+        yarn --cwd /tmp/autodevops test
 
     - name: Generate k8s namespace
       shell: bash

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -30,11 +30,6 @@ runs:
         npx degit SocialGouv/kosko-charts/templates/autodevops /tmp/autodevops
         rm -rf /tmp/autodevops/environments
 
-    - name: Yarn cache setup
-      uses: c-hive/gha-yarn-cache@v2
-      with:
-        directory: /tmp/autodevops
-
     - name: Copy application k8s config to autodevops
       shell: bash
       run: |

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -33,9 +33,10 @@ runs:
     - name: Copy application k8s config to autodevops
       shell: bash
       run: |
+        DEST="/tmp/autodevops"
         if [ -d ".socialgouv/environments" ]; then
-          echo "$ cp -r .socialgouv/environments /tmp/autodevops/environments"
-          cp -r .socialgouv/environments /tmp/autodevops/environments
+          echo "$ cp -r .socialgouv/environments $DEST/environments"
+          cp -r .socialgouv/environments $DEST/environments
         fi
         if [ -d ".socialgouv/components" ]; then
           # use userland components instead of autodevops ones

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -44,7 +44,7 @@ runs:
           # use autodevops kosko-charts template
           echo "$ cp .socialgouv/config.json $DEST/"	
           cp .socialgouv/config.json $DEST/	
-        elif [ -d ".socialgouv/components" ]; then
+        else if [ -d ".socialgouv/components" ]; then
           # use userland `.socialgouv` folder instead of autodevops template when `components` folder is found
           echo "rm -rf $DEST/components"
           rm -rf $DEST/components

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -63,7 +63,8 @@ runs:
     - name: Run kosko manifests tests
       shell: bash
       run: |
-        if [ -f ".socialgouv/__tests__" ]; then
+        if [ -d ".socialgouv/__tests__" ]; then
+          echo "Run kosko manifests tests"
           yarn --cwd /tmp/autodevops test
         fi
 

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -34,20 +34,25 @@ runs:
       shell: bash
       run: |
         DEST="/tmp/autodevops"
+        
         if [ -d ".socialgouv/environments" ]; then
           echo "$ cp -r .socialgouv/environments $DEST/environments"
           cp -r .socialgouv/environments $DEST/environments
         fi
-        if [ -d ".socialgouv/components" ]; then
+
+        if [ -f ".socialgouv/config.json" ]; then	
+          # use autodevops kosko-charts template
+          echo "$ cp .socialgouv/config.json $DEST/"	
+          cp .socialgouv/config.json $DEST/	
+        elif [ -d ".socialgouv/components" ]; then
           # use userland `.socialgouv` folder instead of autodevops template when `components` folder is found
           echo "rm -rf $DEST/components"
           rm -rf $DEST/components
           echo "$ cp -r .socialgouv/* $DEST/"
           cp -r .socialgouv/* $DEST/
-        fi
-        if [ -f ".socialgouv/config.json" ]; then	
-          echo "$ cp .socialgouv/config.json $DEST/"	
-          cp .socialgouv/config.json $DEST/	
+        else;
+          echo "no socialgouv config.json or components found :/"
+          exit 1
         fi
     - name: Install dependencies
       shell: bash

--- a/autodevops-manifests/action.yml
+++ b/autodevops-manifests/action.yml
@@ -44,13 +44,13 @@ runs:
           # use autodevops kosko-charts template
           echo "$ cp .socialgouv/config.json $DEST/"	
           cp .socialgouv/config.json $DEST/	
-        else if [ -d ".socialgouv/components" ]; then
+        elif [ -d ".socialgouv/components" ]; then
           # use userland `.socialgouv` folder instead of autodevops template when `components` folder is found
           echo "rm -rf $DEST/components"
           rm -rf $DEST/components
           echo "$ cp -r .socialgouv/* $DEST/"
           cp -r .socialgouv/* $DEST/
-        else;
+        else
           echo "no socialgouv config.json or components found :/"
           exit 1
         fi


### PR DESCRIPTION
Permet de générer les manifests depuis un dossier `.socialgouv`, avec ou sans custom components.

Les projets doivent déplacer leur `.k8s` dans `.socialgouv`

Si un dossier `__tests__` est présent les tests sont executés