### PR TITLE
fix(yq): do not rely on master for mikefarah/yq

### DIFF
--- a/autodevops-deploy/action.yml
+++ b/autodevops-deploy/action.yml
@@ -30,7 +30,7 @@ runs:
         name: manifests-${{ inputs.environment }}.yml
 
     - name: Get namespace name
-      uses: mikefarah/yq@master
+      uses: mikefarah/yq@v4.13.4
       id: namespace
       with:
         cmd: yq eval '.metadata.name' namespace-${{ inputs.environment }}.yml

--- a/autodevops-restore-db/action.yml
+++ b/autodevops-restore-db/action.yml
@@ -52,7 +52,7 @@ runs:
         SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain || env.SOCIALGOUV_BASE_DOMAIN }}
 
     - name: Get namespace name
-      uses: mikefarah/yq@master
+      uses: mikefarah/yq@v4.13.4
       id: namespace
       with:
         cmd: yq eval '.metadata.name' namespace-${{ inputs.environment }}.yml

--- a/k8s-deactivate/action.yml
+++ b/k8s-deactivate/action.yml
@@ -44,7 +44,7 @@ runs:
         SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain || env.SOCIALGOUV_BASE_DOMAIN }}
 
     - name: Get namespace name
-      uses: mikefarah/yq@master
+      uses: mikefarah/yq@v4.13.4
       id: namespace
       with:
         cmd: yq eval '.metadata.name' namespace-dev.yml

--- a/k8s-funeral/action.yml
+++ b/k8s-funeral/action.yml
@@ -57,7 +57,7 @@ runs:
         SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain || env.SOCIALGOUV_BASE_DOMAIN }}
 
     - name: Get namespace name
-      uses: mikefarah/yq@master
+      uses: mikefarah/yq@v4.13.4
       id: namespace
       with:
         cmd: yq eval '.metadata.name' namespace-dev.yml

--- a/k8s-namespace/action.yml
+++ b/k8s-namespace/action.yml
@@ -48,7 +48,7 @@ runs:
           SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain || env.SOCIALGOUV_BASE_DOMAIN }}
 
       - name: Get namespace name
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@v4.13.4
         id: namespace
         with:
           cmd: yq eval '.metadata.name' namespace-${{ inputs.environment }}.yml

--- a/k8s-restore-db/action.yml
+++ b/k8s-restore-db/action.yml
@@ -52,7 +52,7 @@ runs:
       path: restore-db.yml
 
   - name: Get namespace name
-    uses: mikefarah/yq@master
+    uses: mikefarah/yq@v4.13.4
     id: namespace
     with:
       cmd: yq eval '.metadata.name' namespace-dev.yml


### PR DESCRIPTION
Je viens d'avoir un problème (mais j'ai rebuild donc je ne peux pas prouver mon assertion !) sur une de mes actions car je m'appuyais sur `mikefarah/yq@master`. Et j'ai constaté que son auteur livrait souvent sur `master`. Ça me semble dangereux de parier sur le fait que `master` est bon et ça peut faire perdre du temps (ça m'en a fait perdre le temps que je me rende compte que c'est parce son master était pété). 

Je propose donc de fixer la version, ça nous coutera juste le fait qu'il faudra mettre à jour de temps en temps...