### PR TITLE
fix( k8s-manifests-debug): always recreate comment

### DIFF
--- a/k8s-manifests-debug/action.yml
+++ b/k8s-manifests-debug/action.yml
@@ -49,6 +49,7 @@ runs:
       uses: marocchino/sticky-pull-request-comment@v2
       with:
         number: ${{ steps.finder.outputs.pr }}
+        recreate: true
         message: |
           🎉 Deployment for commit ${{ github.sha }} :
           ${{ steps.debug-manifests.outputs.markdown }}


### PR DESCRIPTION
Always destroy any previous comment and create a new comment with debug info