### PR TITLE
fix(autodevops-create-db): use local NS secret

### DIFF
--- a/autodevops-create-db/action.yml
+++ b/autodevops-create-db/action.yml
@@ -88,7 +88,7 @@ runs:
         PGPASSWORD=$(openssl rand -base64 32 | sed "s/[^[:alnum:]-]//g")
 
         K8S_SECRET_NS="${{ github.event.repository.name }}-secret"
-        PGHOST=$(kubectl -n $K8S_SECRET_NS get secrets $ADMIN_PG_SECRET -o jsonpath="{.data.PGHOST}" | base64 --decode)
+        PGHOST=$(kubectl -n $K8S_NS get secrets $ADMIN_PG_SECRET -o jsonpath="{.data.PGHOST}" | base64 --decode)
 
         if [ "$SOCIALGOUV_PRODUCTION" ]; then
           PGDATABASE=$SOCIALGOUV_PRODUCTION_NAMESPACE


### PR DESCRIPTION
As the admin secret is copied to the target namespace thanks to the `azure-pg-admin-user` label, we dont need to get it from the "secret" namespace