### PR TITLE
fix(restore): allow .socialgouv folders

### DIFF
--- a/k8s-restore-db/action.yml
+++ b/k8s-restore-db/action.yml
@@ -7,7 +7,9 @@ inputs:
     description: "The Rancher project ID, usually secrets.RANCHER_PROJECT_ID"
   socialgouvBaseDomain:
     description: "The base domain name, usually secrets.SOCIALGOUV_BASE_DOMAIN"
-
+  productionNamespace:
+    description: "Override base project name"
+    
 runs:
   using: "composite"
   steps:
@@ -42,6 +44,7 @@ runs:
     env:
       RANCHER_PROJECT_ID: ${{ inputs.rancherId || env.RANCHER_PROJECT_ID }}
       SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain || env.SOCIALGOUV_BASE_DOMAIN }}
+      SOCIALGOUV_PRODUCTION_NAMESPACE: ${{ inputs.productionNamespace }}
 
   - name: Generate restore-db job manifest
     shell: bash

--- a/k8s-restore-db/action.yml
+++ b/k8s-restore-db/action.yml
@@ -9,7 +9,9 @@ inputs:
     description: "The base domain name, usually secrets.SOCIALGOUV_BASE_DOMAIN"
   productionNamespace:
     description: "Override base project name"
-    
+  pgUserSecretPrefix:
+    description: "Prefix for pg-user secret name, oldly azure-pg-user, in future pg-user"
+    default: azure-pg-user
 runs:
   using: "composite"
   steps:
@@ -53,6 +55,7 @@ runs:
       RANCHER_PROJECT_ID: ${{ inputs.rancherId || env.RANCHER_PROJECT_ID }}
       SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain || env.SOCIALGOUV_BASE_DOMAIN }}
       SOCIALGOUV_PRODUCTION_NAMESPACE: ${{ inputs.productionNamespace }}
+      PG_USER_SECRET_PREFIX: ${{ inputs.pgUserSecretPrefix }}
       
   - name: Archive restore-db job
     uses: actions/upload-artifact@v2

--- a/k8s-restore-db/action.yml
+++ b/k8s-restore-db/action.yml
@@ -52,7 +52,8 @@ runs:
     env:
       RANCHER_PROJECT_ID: ${{ inputs.rancherId || env.RANCHER_PROJECT_ID }}
       SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain || env.SOCIALGOUV_BASE_DOMAIN }}
-
+      SOCIALGOUV_PRODUCTION_NAMESPACE: ${{ inputs.productionNamespace }}
+      
   - name: Archive restore-db job
     uses: actions/upload-artifact@v2
     with:

--- a/k8s-restore-db/action.yml
+++ b/k8s-restore-db/action.yml
@@ -17,30 +17,34 @@ runs:
 
   - name: Load environment variables
     shell: bash
+    id: env
     run: |
       if test -f ".github/dev.env"; then
         cat ".github/dev.env" >> $GITHUB_ENV
       fi
+      K8S_FOLDER=[[ -d ".k8s" ]] && ".k8s" || ".socialgouv"
+      echo $K8S_FOLDER
+      echo "::set-output name=K8S_FOLDER::$K8S_FOLDER"
 
   - name: Yarn cache setup
     uses: c-hive/gha-yarn-cache@v2
     with:
-      directory: .k8s
+      directory: ${{ steps.env.outputs.K8S_FOLDER }}
 
   - name: Install kosko-charts dependencies
     shell: bash
-    run: yarn --cwd .k8s install --frozen-lockfile --prefer-offline
+    run: yarn --cwd ${{ steps.env.outputs.K8S_FOLDER }} install --frozen-lockfile --prefer-offline
 
   - name: Generate k8s namespace
     shell: bash
-    run: yarn --cwd .k8s --silent generate --env dev _namespace > namespace-dev.yml
+    run: yarn --cwd ${{ steps.env.outputs.K8S_FOLDER }} --silent generate --env dev _namespace > namespace-dev.yml
     env:
       RANCHER_PROJECT_ID: ${{ inputs.rancherId || env.RANCHER_PROJECT_ID }}
       SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain || env.SOCIALGOUV_BASE_DOMAIN }}
 
   - name: Generate restore-db job manifest
     shell: bash
-    run: yarn --cwd .k8s --silent generate --env dev jobs/restore > restore-db.yml
+    run: yarn --cwd ${{ steps.env.outputs.K8S_FOLDER }} --silent generate --env dev jobs/restore > restore-db.yml
     env:
       RANCHER_PROJECT_ID: ${{ inputs.rancherId || env.RANCHER_PROJECT_ID }}
       SOCIALGOUV_BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain || env.SOCIALGOUV_BASE_DOMAIN }}

--- a/k8s-restore-db/action.yml
+++ b/k8s-restore-db/action.yml
@@ -22,7 +22,8 @@ runs:
       if test -f ".github/dev.env"; then
         cat ".github/dev.env" >> $GITHUB_ENV
       fi
-      K8S_FOLDER=[[ -d ".k8s" ]] && ".k8s" || ".socialgouv"
+      if [-d ".k8s"]; then K8S_FOLDER=".k8s"; fi
+      if [-d ".socialgouv"]; then K8S_FOLDER=".socialgouv"; fi
       echo $K8S_FOLDER
       echo "::set-output name=K8S_FOLDER::$K8S_FOLDER"
 

--- a/k8s-restore-db/action.yml
+++ b/k8s-restore-db/action.yml
@@ -22,8 +22,8 @@ runs:
       if test -f ".github/dev.env"; then
         cat ".github/dev.env" >> $GITHUB_ENV
       fi
-      if [-d ".k8s"]; then K8S_FOLDER=".k8s"; fi
-      if [-d ".socialgouv"]; then K8S_FOLDER=".socialgouv"; fi
+      if [ -d ".k8s" ]; then K8S_FOLDER=".k8s"; fi
+      if [ -d ".socialgouv" ]; then K8S_FOLDER=".socialgouv"; fi
       echo $K8S_FOLDER
       echo "::set-output name=K8S_FOLDER::$K8S_FOLDER"
 


### PR DESCRIPTION
a patch for 1000jours/restore and carnet-de-bord/restore

this action is different than `autodevops/restore-db` because it use a kosko job defined in the project itself. 