### PR TITLE
fix(autodevops-helm-deploy): use inputs.baseSubdomain

### DIFF
--- a/autodevops-helm-deploy/action.yml
+++ b/autodevops-helm-deploy/action.yml
@@ -51,6 +51,7 @@ runs:
       shell: bash
       env:
         BASE_DOMAIN: ${{ inputs.socialgouvBaseDomain }}
+        BASE_SUBDOMAIN: ${{ inputs.baseSubdomain }}
         PRODUCTION_HOST: ${{ inputs.productionHost }}
         IMAGE_NAME: ${{ inputs.imageName }}
         HELM_ARGS: ${{ inputs.helmArgs }}


### PR DESCRIPTION
Add missing env variable for manifests generation