### PR TITLE
fix: remove unnecessary auto deactivation

### DIFF
--- a/autodevops-deactivate/action.yml
+++ b/autodevops-deactivate/action.yml
@@ -50,11 +50,3 @@ runs:
       with:
         kubeconfig: ${{ inputs.kube-config }}
         adminPgSecret: ${{ inputs.adminPgSecret }}
-
-    - name: Mark environment as deactivated
-      uses: bobheadxi/deployments@v0.4.3
-      with:
-        step: deactivate-env
-        token: ${{ inputs.github-token }}
-        env: ${{ steps.k8s.outputs.namespace }}
-        desc: "Environment ${{ steps.k8s.outputs.namespace }} has been deactivated"


### PR DESCRIPTION
Par défaut, lorsqu'un environment est crée, on utilise le paramètre `transcient_environment`. Celui-ci signifie que lors d'une PR, l'environment sera détruit : <https://docs.github.com/en/rest/reference/deployments#create-a-deployment--parameters>

Par conséquent, nous nous en avons plus besoin